### PR TITLE
Fix resources not loading on new window in Firefox

### DIFF
--- a/src/pages/Presentation.tsx
+++ b/src/pages/Presentation.tsx
@@ -93,7 +93,7 @@ export class Presentation extends React.Component<
         let baseEl = window.document.createElement("base");
         baseEl.href = new URL(parentWindow?.location.href ?? "http://localhost:3000").origin;
 
-        window.document.head;
+        window.document.head.append(baseEl);
       }
     } catch (error) {
       // Silent fail

--- a/src/pages/Presentation.tsx
+++ b/src/pages/Presentation.tsx
@@ -87,6 +87,21 @@ export class Presentation extends React.Component<
   onOpen(window: Window) {
     const parentWindow = window.opener as Window | undefined | null;
 
+    try {
+      const base = window.document.head.querySelector("base");
+      if (!base) {
+        let baseEl = window.document.createElement("base");
+        baseEl.href = new URL(parentWindow?.location.href ?? "http://localhost:3000").origin;
+
+        window.document.head;
+      }
+    } catch (error) {
+      // Silent fail
+      // Usually, this will make only Firefox happy.
+
+      // Somehow chrome resolves the base url from the parent, idk why
+    }
+
     this.setState({
       window: parentWindow,
     });


### PR DESCRIPTION
Simply appends `<base>` tag to the presentation view window, with `href` set to the parent's url origin.